### PR TITLE
feat(server): Require basic authorization

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -25,5 +25,7 @@ func start() {
 
 	app.Get("/getMostOccurring/:id", handlers.GetMostOccurring)
 
+	app.Get("/getPDF/:id/:page", handlers.GetPdfPage)
+
 	app.Listen(":3000")
 }

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -19,5 +19,7 @@ func start() {
 
 	app.Get("/getPDF/:id", handlers.GetPDF)
 
+	app.Get("/getOccurrence/:id/:key", handlers.GetOccurrence)
+
 	app.Listen(":3000")
 }

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -11,6 +11,8 @@ func start() {
 
 	app.Get("/", handlers.Home)
 
+	app.Use(handlers.BasicAuthMiddleware("username", "password"))
+
 	app.Post("/uploadPDF", handlers.SaveFile)
 
 	app.Get("/listPDF", handlers.ListFiles)

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -27,7 +27,7 @@ func start() {
 
 	app.Get("/getPDF/:id/:page", handlers.GetPdfPage)
 
-	app.Post("/deletePDF", handlers.DeleteFile)
+	app.Delete("/deletePDF", handlers.DeleteFile)
 
 	app.Listen(":3000")
 }

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -23,5 +23,7 @@ func start() {
 
 	app.Get("/getOccurrence/:id/:key", handlers.GetOccurrence)
 
+	app.Get("/getMostOccurring/:id", handlers.GetMostOccurring)
+
 	app.Listen(":3000")
 }

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -27,5 +27,7 @@ func start() {
 
 	app.Get("/getPDF/:id/:page", handlers.GetPdfPage)
 
+	app.Post("/deletePDF", handlers.DeleteFile)
+
 	app.Listen(":3000")
 }

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -19,6 +19,8 @@ func start() {
 
 	app.Get("/getPDF/:id", handlers.GetPDF)
 
+	app.Get("/listSentences/:id", handlers.ListSentences)
+
 	app.Get("/getOccurrence/:id/:key", handlers.GetOccurrence)
 
 	app.Listen(":3000")

--- a/database/query.sql.go
+++ b/database/query.sql.go
@@ -66,11 +66,11 @@ func (q *Queries) CreateSentence(ctx context.Context, arg CreateSentenceParams) 
 
 const deleteRecord = `-- name: DeleteRecord :exec
 DELETE FROM records
-WHERE id = $1
+WHERE name = $1
 `
 
-func (q *Queries) DeleteRecord(ctx context.Context, id int32) error {
-	_, err := q.db.Exec(ctx, deleteRecord, id)
+func (q *Queries) DeleteRecord(ctx context.Context, name string) error {
+	_, err := q.db.Exec(ctx, deleteRecord, name)
 	return err
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.8'
 services:
-  web:
+  server:
     build: .
     env_file:
       - .env
@@ -30,7 +30,7 @@ services:
     environment:
       - MINIO_ROOT_USER=minioadmin
       - MINIO_ROOT_PASSWORD=minioadmin
-    command: server --console-address ":9090" /minio/mnt/data
+    command: server --console-address ":9090" /data
     volumes:
       - minio_data:/data
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     command: server --console-address ":9090" /minio/mnt/data
     volumes:
       - minio_data:/data
-      - minio_config:/root/.minio
 volumes:
   minio_data:
-  minio_config:
   postgres-db:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require github.com/jackc/pgx/v4 v4.18.1
 
 require (
+	github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
@@ -22,12 +23,14 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/xid v1.5.0 // indirect
 	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/unidoc/pkcs7 v0.2.0 // indirect
 	github.com/unidoc/timestamp v0.0.0-20200412005513-91597fd3793a // indirect
 	github.com/unidoc/unitype v0.2.1 // indirect
+	github.com/wayneashleyberry/terminal-dimensions v1.1.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	golang.org/x/image v0.5.0 // indirect
 	golang.org/x/net v0.12.0 // indirect
@@ -42,6 +45,7 @@ require (
 require (
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/dslipak/pdf v0.0.1
+	github.com/gen2brain/go-fitz v1.22.2
 	github.com/gofiber/fiber/v2 v2.48.0 // indirect
 	github.com/golang-migrate/migrate/v4 v4.16.2
 	github.com/google/uuid v1.3.0 // indirect
@@ -66,6 +70,7 @@ require (
 	github.com/neurosnap/sentences v1.1.2
 	github.com/pdfcpu/pdfcpu v0.4.2
 	github.com/pkg/errors v0.9.1
+	github.com/qeesung/image2ascii v1.0.1
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/sirupsen/logrus v1.9.3
 	github.com/unidoc/unipdf/v3 v3.49.0

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 
 require (
 	github.com/andybalholm/brotli v1.0.5 // indirect
+	github.com/bbalet/stopwords v1.0.0
 	github.com/dslipak/pdf v0.0.1
 	github.com/gen2brain/go-fitz v1.22.2
 	github.com/gofiber/fiber/v2 v2.48.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59 h1:WWB576BN5zNSZc/M9d/10pqEx5VHNhaQ/yOVAkmj5Yo=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
+github.com/bbalet/stopwords v1.0.0 h1:0TnGycCtY0zZi4ltKoOGRFIlZHv0WqpoIGUsObjztfo=
+github.com/bbalet/stopwords v1.0.0/go.mod h1:sAWrQoDMfqARGIn4s6dp7OW7ISrshUD8IP2q3KoqPjc=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
+github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59 h1:WWB576BN5zNSZc/M9d/10pqEx5VHNhaQ/yOVAkmj5Yo=
+github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -18,6 +20,8 @@ github.com/dslipak/pdf v0.0.1/go.mod h1:2L3SnkI9cQwnAS9gfPz2iUoLC0rUZwbucpbKi5R1
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
+github.com/gen2brain/go-fitz v1.22.2 h1:pisRYS3x/tvsiS4UzdBoiStmOxYoisOGNCUB4+0RKhE=
+github.com/gen2brain/go-fitz v1.22.2/go.mod h1:HU04vc+RisUh/kvEd2pB0LAxmK1oyXdN4ftyshUr9rQ=
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
 github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
@@ -158,6 +162,8 @@ github.com/montanaflynn/stats v0.6.3/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFW
 github.com/neurosnap/sentences v1.0.6/go.mod h1:pg1IapvYpWCJJm/Etxeh0+gtMf1rI1STY9S7eUCPbDc=
 github.com/neurosnap/sentences v1.1.2 h1:iphYOzx/XckXeBiLIUBkPu2EKMJ+6jDbz/sLJZ7ZoUw=
 github.com/neurosnap/sentences v1.1.2/go.mod h1:/pwU4E9XNL21ygMIkOIllv/SMy2ujHwpf8GQPu1YPbQ=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/pdfcpu/pdfcpu v0.4.2 h1:d9fzymrsR0k+iJmr/AtHnalP+JO09dq2DeEYnghm+Rg=
 github.com/pdfcpu/pdfcpu v0.4.2/go.mod h1:MojCBFW2uljNs3CBmyTDeFAvu7vI1LrJhWNMCjY3kg4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -165,6 +171,8 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/qeesung/image2ascii v1.0.1 h1:Fe5zTnX/v/qNC3OC4P/cfASOXS501Xyw2UUcgrLgtp4=
+github.com/qeesung/image2ascii v1.0.1/go.mod h1:kZKhyX0h2g/YXa/zdJR3JnLnJ8avHjZ3LrvEKSYyAyU=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
@@ -217,6 +225,8 @@ github.com/valyala/fasthttp v1.48.0 h1:oJWvHb9BIZToTQS3MuQ2R3bJZiNSa2KiNdeI8A+79
 github.com/valyala/fasthttp v1.48.0/go.mod h1:k2zXd82h/7UZc3VOdJ2WaUqt1uZ/XpXAfE9i+HBC3lA=
 github.com/valyala/tcplisten v1.0.0 h1:rBHj/Xf+E1tRGZyWIWwJDiRY0zc1Js+CV5DqwacVSA8=
 github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
+github.com/wayneashleyberry/terminal-dimensions v1.1.0 h1:EB7cIzBdsOzAgmhTUtTTQXBByuPheP/Zv1zL2BRPY6g=
+github.com/wayneashleyberry/terminal-dimensions v1.1.0/go.mod h1:2lc/0eWCObmhRczn2SdGSQtgBooLUzIotkkEGXqghyg=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -233,6 +233,29 @@ func GetPDF(c *fiber.Ctx) error {
 	return c.SendFile(localFile.Name())
 }
 
+func ListSentences(c *fiber.Ctx) error {
+	id, err := c.ParamsInt("id", -1)
+	if err != nil || id == -1 {
+		return utils.SendBadRequestStatus(c, "Id invalid or not provided")
+	}
+
+	ctx := c.Context()
+	url := fmt.Sprintf("postgres://%s:%s@db:5432", os.Getenv("DB_USER"), os.Getenv("DB_NAME"))
+	conn, err := pgx.Connect(ctx, url)
+	if err != nil {
+		return utils.SendErrorStatus(c, "Failed to connect to the database")
+	}
+
+	queries := database.New(conn)
+
+	sentences, err := queries.ListRecordSentences(ctx, int32(id))
+	if err != nil {
+		return utils.SendErrorStatus(c, "Failed to retrieve the list of sentences for the selected file")
+	}
+
+	return c.JSON(sentences)
+}
+
 func GetOccurrence(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id", -1)
 	if id == -1 || err != nil {

--- a/query.sql
+++ b/query.sql
@@ -20,7 +20,7 @@ RETURNING *;
 
 -- name: DeleteRecord :exec
 DELETE FROM records
-WHERE id = $1;
+WHERE name = $1;
 
 -- name: UpdateRecord :exec
 UPDATE records

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -85,7 +85,7 @@ func CountFilteredWords(text string) map[string]int {
 		"very", "was", "wasn't", "we", "we'd", "we'll", "we're", "we've", "were", "weren't",
 		"what", "what's", "when", "when's", "where", "where's", "which", "while", "who",
 		"who's", "whom", "why", "why's", "with", "won't", "would", "wouldn't", "you", "you'd",
-		"you'll", "you're", "you've", "your", "yours", "yourself", "yourselves",
+		"you'll", "you're", "you've", "your", "yours", "yourself", "yourselves", "can",
 	}
 
 	filteredWords := map[string]int{}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bbalet/stopwords"
 	"github.com/dslipak/pdf"
 	"github.com/gen2brain/go-fitz"
 	"github.com/gofiber/fiber/v2"
@@ -170,37 +171,14 @@ func ReadPdf(path string) (*pdf.Reader, string, error) {
 }
 
 func CountFilteredWords(text string) map[string]int {
-
-	trim := strings.TrimSpace(text)
-	words := strings.Split(trim, " ")
-	stopWords := []string{
-		"a", "b", "c", "d", "e", "f", "g", "h", "i", "j",
-		"k", "l", "m", "n", "o", "p", "q", "r", "s", "t",
-		"u", "v", "w", "x", "y", "z", "about", "above", "after", "again", "against", "all", "am", "an", "and",
-		"any", "are", "aren't", "as", "at", "be", "because", "been", "before", "being",
-		"below", "between", "both", "but", "by", "can't", "cannot", "could", "couldn't",
-		"did", "didn't", "do", "does", "doesn't", "doing", "don't", "down", "during",
-		"each", "few", "for", "from", "further", "had", "hadn't", "has", "hasn't", "have",
-		"haven't", "having", "he", "he'd", "he'll", "he's", "her", "here", "here's", "hers",
-		"herself", "him", "himself", "his", "how", "how's", "i", "i'd", "i'll", "i'm",
-		"i've", "if", "in", "into", "is", "isn't", "it", "it's", "its", "itself", "let's",
-		"me", "more", "most", "mustn't", "my", "myself", "no", "nor", "not", "of", "off",
-		"on", "once", "only", "or", "other", "ought", "our", "ours", "ourselves", "out",
-		"over", "own", "same", "shan't", "she", "she'd", "she'll", "she's", "should",
-		"shouldn't", "so", "some", "such", "than", "that", "that's", "the", "their", "theirs",
-		"them", "themselves", "then", "there", "there's", "these", "they", "they'd", "they'll",
-		"they're", "they've", "this", "those", "through", "to", "too", "under", "until", "up",
-		"very", "was", "wasn't", "we", "we'd", "we'll", "we're", "we've", "were", "weren't",
-		"what", "what's", "when", "when's", "where", "where's", "which", "while", "who",
-		"who's", "whom", "why", "why's", "with", "won't", "would", "wouldn't", "you", "you'd",
-		"you'll", "you're", "you've", "your", "yours", "yourself", "yourselves", "can",
-	}
-
-	filteredWords := map[string]int{}
 	reg := regexp.MustCompile("[^a-zA-Z]+")
+	pointless := reg.ReplaceAllString(text, " ")
+	clean := stopwords.CleanString(pointless, "en", false)
+	words := strings.Split(clean, " ")
+	fmt.Println(clean)
+	filteredWords := map[string]int{}
+
 	for _, word := range words {
-		word = reg.ReplaceAllString(word, " ")
-		word = strings.TrimSpace(word)
 		if strings.Contains(word, " ") {
 			for key, value := range CountFilteredWords(word) {
 				val := filteredWords[key]
@@ -212,19 +190,9 @@ func CountFilteredWords(text string) map[string]int {
 			continue
 		}
 
-		isStopWord := false
-		for _, stopWord := range stopWords {
-			if strings.ToLower(word) == stopWord {
-				isStopWord = true
-				break
-			}
-		}
-
-		if !isStopWord {
-			count := filteredWords[word]
-			count++
-			filteredWords[word] = count
-		}
+		count := filteredWords[word]
+		count++
+		filteredWords[word] = count
 	}
 
 	return filteredWords

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -36,6 +36,12 @@ func SendErrorStatus(c *fiber.Ctx, err string) error {
 	})
 }
 
+func SendBadRequestStatus(c *fiber.Ctx, err string) error {
+	return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+		"error": err,
+	})
+}
+
 func ReadPdf(path string) (*pdf.Reader, string, error) {
 	r, err := pdf.Open(path)
 	if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,7 +3,12 @@ package utils
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"log"
 	"main/database"
+	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/dslipak/pdf"
 	"github.com/gofiber/fiber/v2"
@@ -54,4 +59,84 @@ func ReadPdf(path string) (*pdf.Reader, string, error) {
 	}
 	buf.ReadFrom(b)
 	return r, buf.String(), nil
+}
+
+func CountFilteredWords(text string) map[string]int {
+
+	trim := strings.TrimSpace(text)
+	words := strings.Split(trim, " ")
+	stopWords := []string{
+		"a", "b", "c", "d", "e", "f", "g", "h", "i", "j",
+		"k", "l", "m", "n", "o", "p", "q", "r", "s", "t",
+		"u", "v", "w", "x", "y", "z", "about", "above", "after", "again", "against", "all", "am", "an", "and",
+		"any", "are", "aren't", "as", "at", "be", "because", "been", "before", "being",
+		"below", "between", "both", "but", "by", "can't", "cannot", "could", "couldn't",
+		"did", "didn't", "do", "does", "doesn't", "doing", "don't", "down", "during",
+		"each", "few", "for", "from", "further", "had", "hadn't", "has", "hasn't", "have",
+		"haven't", "having", "he", "he'd", "he'll", "he's", "her", "here", "here's", "hers",
+		"herself", "him", "himself", "his", "how", "how's", "i", "i'd", "i'll", "i'm",
+		"i've", "if", "in", "into", "is", "isn't", "it", "it's", "its", "itself", "let's",
+		"me", "more", "most", "mustn't", "my", "myself", "no", "nor", "not", "of", "off",
+		"on", "once", "only", "or", "other", "ought", "our", "ours", "ourselves", "out",
+		"over", "own", "same", "shan't", "she", "she'd", "she'll", "she's", "should",
+		"shouldn't", "so", "some", "such", "than", "that", "that's", "the", "their", "theirs",
+		"them", "themselves", "then", "there", "there's", "these", "they", "they'd", "they'll",
+		"they're", "they've", "this", "those", "through", "to", "too", "under", "until", "up",
+		"very", "was", "wasn't", "we", "we'd", "we'll", "we're", "we've", "were", "weren't",
+		"what", "what's", "when", "when's", "where", "where's", "which", "while", "who",
+		"who's", "whom", "why", "why's", "with", "won't", "would", "wouldn't", "you", "you'd",
+		"you'll", "you're", "you've", "your", "yours", "yourself", "yourselves",
+	}
+
+	filteredWords := map[string]int{}
+	reg := regexp.MustCompile("[^a-zA-Z]+")
+	for _, word := range words {
+		word = reg.ReplaceAllString(word, " ")
+		word = strings.TrimSpace(word)
+		if strings.Contains(word, " ") {
+			for key, value := range CountFilteredWords(word) {
+				val := filteredWords[key]
+				filteredWords[key] = value + val
+			}
+			continue
+		}
+		if word == "" {
+			continue
+		}
+
+		isStopWord := false
+		for _, stopWord := range stopWords {
+			if strings.ToLower(word) == stopWord {
+				isStopWord = true
+				break
+			}
+		}
+
+		if !isStopWord {
+			count := filteredWords[word]
+			count++
+			filteredWords[word] = count
+		}
+	}
+
+	return filteredWords
+}
+
+func ExtractFrequency(entry string) int {
+	if entry == "" {
+		return 0
+	}
+
+	freq, err := strconv.Atoi(strings.Split(entry, " ")[1])
+	if err != nil {
+		log.Fatalln(err)
+	}
+	return freq
+}
+
+func ShiftAndUpdateTopFive(index int, key string, value int, topFive *map[int]string) {
+	for i := 5; i > index; i-- {
+		(*topFive)[i] = (*topFive)[i-1]
+	}
+	(*topFive)[index] = fmt.Sprintf("%s: %d times", key, value)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -232,22 +232,17 @@ func ShiftAndUpdateTopFive(index int, key string, value int, topFive *map[int]st
 	(*topFive)[index] = fmt.Sprintf("%s: %d times", key, value)
 }
 
-func CopyPDF(c *fiber.Ctx) (string, error) {
-	id, err := c.ParamsInt("id", -1)
-	if err != nil || id == -1 {
-		return "", SendErrorStatus(c, "Invalid id provided")
-	}
-
-	ctx := c.Context()
+func CopyPDF(id int) (string, error) {
+	ctx := context.Background()
 	record, err := GetRecord(ctx, int32(id))
 	if err != nil {
-		return "", SendErrorStatus(c, "A file with the id provided does not exist")
+		return "A file with the id provided does not exist", err
 	}
 
 	// Initialize MinIO client
 	minioClient, err := getMinioClient()
 	if err != nil {
-		return "", SendErrorStatus(c, "Failed to initialize minio client")
+		return "Failed to initialize minio client", err
 	}
 
 	//download file from MinIO
@@ -256,13 +251,13 @@ func CopyPDF(c *fiber.Ctx) (string, error) {
 
 	file, err := minioClient.GetObject(ctx, bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
-		return "", SendErrorStatus(c, "Failed to get the file from MinIO")
+		return "Failed to get the file from MinIO", err
 	}
 	defer file.Close()
 
 	localFile, err := os.Create(record.Name)
 	if err != nil {
-		return "", SendErrorStatus(c, "Failed to create a temporary copy of the file")
+		return "Failed to create a temporary copy of the file", err
 	}
 	defer localFile.Close()
 


### PR DESCRIPTION
1- Added a middleware function `BasicAuthMiddleware(username, password)` that requires basic authorization to use all of the api functions other than the default route. A user would need to add an authorization header of type `Basic Auth` with the username and password to be able to access the api.

2- Refactored the `CopyPDF()` utils function and handlers that use it to take in the id instead of the fiber context.

3- Fixed the docker compose file to preserve minio data.